### PR TITLE
added inpainting functionality to noise model class. 

### DIFF
--- a/mnms/utils.py
+++ b/mnms/utils.py
@@ -652,3 +652,44 @@ def get_seed(split_num, sim_num, data_model, *qids, n_max_qids=4, ndigits=9):
     for i in range(len(qids)):
         seed[i+3] = hash_qid(qids[i], ndigits=ndigits)
     return seed
+
+def get_mask_bool(mask, threshold=1e-3):
+    """
+    Return a boolean version of the input mask.
+
+    Parameters
+    ----------
+    mask : enmap
+        Input sky mask.
+    threshold : float, optional
+        Consider values below this number as unobserved (False).
+
+    Returns
+    -------
+    mask_bool : bool enmap
+        Boolean version of input mask.
+    """
+
+    # Makes a copy even if mask is already boolean, which is good.
+    mask_bool = mask.astype(bool)
+    if mask.dtype != bool:
+        mask_bool[mask < threshold] = False
+    return mask_bool
+
+def get_catalog(union_sources):
+    """Load and process source catalog.
+
+    Parameters
+    ----------
+    union_sources : str
+        A soapack source catalog.
+
+    Returns
+    -------
+    catalog : (2, N) array
+        DEC and RA values (in radians) for each point source.
+    """
+
+    ra, dec = sints.get_act_mr3f_union_sources(version=union_sources)
+    return np.radians(np.vstack([dec, ra]))        
+

--- a/scripts/noise_gen_tile.py
+++ b/scripts/noise_gen_tile.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 
 data_model = getattr(sints,args.data_model)()
 model = nm.TiledNoiseModel(
-    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version, mask_name=args.mask_name, notes=args.notes,
-    width_deg=args.width_deg, height_deg=args.height_deg, delta_ell_smooth=args.delta_ell_smooth
-    )
+    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version,
+    mask_name=args.mask_name, notes=args.notes, width_deg=args.width_deg, height_deg=args.height_deg,
+    delta_ell_smooth=args.delta_ell_smooth, union_sources=args.union_sources)
 model.get_model(check_on_disk=False, verbose=True)

--- a/scripts/noise_gen_wav.py
+++ b/scripts/noise_gen_wav.py
@@ -41,7 +41,7 @@ args = parser.parse_args()
 
 data_model = getattr(sints,args.data_model)()
 model = nm.WaveletNoiseModel(
-    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version, mask_name=args.mask_name, notes=args.notes,
-    lamb=args.lamb, lmax=args.lmax, smooth_loc=args.smooth_loc
-    )
+    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version,
+    mask_name=args.mask_name, notes=args.notes, lamb=args.lamb, lmax=args.lmax, 
+    smooth_loc=args.smooth_loc, union_sources=args.union_sources)
 model.get_model(check_on_disk=False, verbose=True)

--- a/scripts/noise_sim_tile.py
+++ b/scripts/noise_sim_tile.py
@@ -34,9 +34,9 @@ args = parser.parse_args()
 
 data_model = getattr(sints,args.data_model)()
 model = nm.TiledNoiseModel(
-    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version, mask_name=args.mask_name, notes=args.notes,
-    width_deg=args.width_deg, height_deg=args.height_deg, delta_ell_smooth=args.delta_ell_smooth
-    )
+    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version,
+        mask_name=args.mask_name, notes=args.notes, width_deg=args.width_deg, height_deg=args.height_deg,
+        delta_ell_smooth=args.delta_ell_smooth, union_sources=args.union_sources)
 
 # get split nums
 if args.auto_split:

--- a/scripts/noise_sim_wav.py
+++ b/scripts/noise_sim_wav.py
@@ -70,9 +70,9 @@ args = parser.parse_args()
 
 data_model = getattr(sints,args.data_model)()
 model = nm.WaveletNoiseModel(
-    *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version, mask_name=args.mask_name, notes=args.notes,
-    lamb=args.lamb, lmax=args.lmax, smooth_loc=args.smooth_loc
-    )
+        *args.qid, data_model=data_model, downgrade=args.downgrade, mask_version=args.mask_version,
+        mask_name=args.mask_name, notes=args.notes, lamb=args.lamb, lmax=args.lmax,
+        smooth_loc=args.smooth_loc, union_sources=args.union_sources)
 
 # get split nums
 if args.auto_split:


### PR DESCRIPTION
Used automatically when union_sources is provided. Does not inpaint the ivar. Looks like dr6v2 does not need it, so we are only inpainting the data